### PR TITLE
Update license, repository metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,9 @@ name = "codejson-index-generator"
 version = "1.0.0"
 description = "Script to create an indexed code.json for agencies."
 authors = ["Sachin Panayil <sachinpanayil01@gmail.com>"]
-license = "CC0 1.0"
+license = "CC0-1.0"
 readme = "README.md"
+repository = "https://github.com/DSACMS/codejson-index-generator"
 
 [tool.poetry.dependencies]
 python = "^3.13"


### PR DESCRIPTION
## Update license, repository metadata

## Problem

Great work getting this shipped! I took a look at the PyPi page and noticed it wasn't handling the license identifier and there wasn't a link back to the repo.

<img width="285" alt="Screenshot 2025-05-09 at 7 16 36 AM" src="https://github.com/user-attachments/assets/32e1c0f6-6d34-408f-8a21-29a89ecb6d01" />

## Solution

I made a small change to update the license identifier to the SPDX format by adding a dash. I also added the `repository` field under `tool.poetry` so that should render in the "Unverified Details" section and allow people to get back to the repo more easily.

Quick note that technically this is deprecated and Poetry is moving toward following the [PyPA specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table) more closely, but that's a much bigger change and I don't imagine a high priority.

## Test Plan

Not really a clear way to test without publishing that I'm aware of unless there's a dry run option, 
