### PR TITLE
Remove PyGithub and Add Support for Gitlab and Bitbucket

### DIFF
--- a/codejson_index_generator/parsers.py
+++ b/codejson_index_generator/parsers.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import requests
 import re
+import subprocess
 
 from time import sleep, mktime, gmtime, time, localtime
 from typing import Dict, Optional
@@ -114,12 +115,15 @@ class IndexGenerator:
         except (json.JSONDecodeError, ValueError) as e:
             print(f"JSON Error: {str(e)}")
             return None
+    
+    def get_code_json_other(self,repo: str) -> Optional[Dict]:
+        return None
 
     def get_code_json(self, repo: str) -> Optional[Dict]:
         if 'github' in repo:
             return self.get_code_json_github(repo)
         else:
-            return None
+            return self.get_code_json_other(repo)
     
     def save_code_json(self, repo: str, output_path: str) -> Optional[str]:
         

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def main():
 
         for org in args.orgs.split(","):
             org = org.strip()
-            indexGen.process_organization(org)
+            indexGen.process_github_org_files(org)
 
         indexGen.save_index(args.output)
         print(f"\nIndexing complete. Results saved to {args.output}")

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def main():
     try:
         indexGen = IndexGenerator(
             agency = args.agency,
-            verison = args.version, 
+            version = args.version, 
             token = github_key
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/DSACMS/codejson-index-generator"
 [tool.poetry.dependencies]
 python = "^3.13"
 requests = "^2.32.4"
+llnl-scraper = "^0.15.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/DSACMS/codejson-index-generator"
 
 [tool.poetry.dependencies]
 python = "^3.13"
-pygithub = ">=1.59,<2.0"
+requests = "^2.32.4"
 
 
 [build-system]


### PR DESCRIPTION
# Remove PyGithub and Add Support for Gitlab and Bitbucket

## Problem

PyGithub has less control over rate limiting than I would like it too for our purposes. We also did not previously have support for platforms other than GitHub

## Solution

Remove PyGithub. Add functionality to fetch code.json files from GitLab and Bitbucket.

##Testing

Ran `main.py` locally